### PR TITLE
Don't use ES6 syntax unless you are transpiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const breakBuild = (buildHasErrors) => {
 };
 
 module.exports = function(content, sourceMap) {
-  let buildHasErrors = false;
+  var buildHasErrors = false;
   if (sourceMap.messages.length > 0) {
     console.log(`File: ${sourceMap.opts.from}`.yellow);
     for (msg in sourceMap.messages) {


### PR DESCRIPTION
Don't use ES6 'let' syntax unless transpiling to an ES5 compatible distribution.
